### PR TITLE
Unstable bugfix

### DIFF
--- a/Messenger/Messenger/Views/NavigationPanels/TeamNavPage.xaml
+++ b/Messenger/Messenger/Views/NavigationPanels/TeamNavPage.xaml
@@ -110,7 +110,6 @@
         </ScrollViewer>
         <Button
             x:Name="newChat"
-            Grid.Row="1"
             Style="{StaticResource NewTeamButtonStyle}"
             Command="{x:Bind ViewModel.CreateTeamCommand}"
             Grid.Row="1">


### PR DESCRIPTION
# Before this PR can be merged, the following checkboxes have to be ticked


- [x] This code belongs to the backend and is tested, or tests are not useful
- [x] New functions with more than 5 lines have docstrings
- [x] New code has been integrated with the `MessengerService` if appropiate
- [x] New code has been integrated with the `SignalRService` if appropiate
- [x] New functions or classes have been documented in the _Entwurfsdokumentation_
- [x] Changes introduce no commented out code or `Console.Writeline()` statements used for debugging

# Related issues:
<!-- list of issue closing directives
     e.g. - Closes #999
-->
