### PR TITLE
Restyle `TeamNavPage` and `ChatNavPage` / `Message` bound to `Channel`s

### DIFF
--- a/Messenger/Messenger/Controls/ChatControls/ChatHeader.xaml
+++ b/Messenger/Messenger/Controls/ChatControls/ChatHeader.xaml
@@ -6,9 +6,13 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:icons="using:MahApps.Metro.IconPacks"
+    xmlns:converters="using:Messenger.Helpers"
     mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="400">
+    <UserControl.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+    </UserControl.Resources>
     <Grid
         VerticalAlignment="Center">
         <Grid.ColumnDefinitions>
@@ -41,18 +45,35 @@
             <StackPanel
                 Orientation="Horizontal"
                 VerticalAlignment="Center"
-                Spacing="10">
-                <TextBlock
-                    FontWeight="Bold"
-                    FontSize="26"
-                    Text="{x:Bind CurrentTeam.TeamName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                    />
+                Spacing="25">
+                <StackPanel
+                    Spacing="-3">
+                    <TextBlock
+                        FontWeight="Bold"
+                        FontSize="24"
+                        Visibility="{x:Bind CurrentTeam.IsPrivateChat, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter='invert'}"
+                        Text="{x:Bind CurrentTeam.TeamName, Mode=OneWay}"
+                        />
+                    <TextBlock
+                        FontWeight="Bold"
+                        FontSize="26"
+                        Text="{x:Bind CurrentTeam.Members[0].DisplayName, Mode=OneWay}"
+                        Visibility="{x:Bind CurrentTeam.IsPrivateChat, Converter={StaticResource BoolToVisibilityConverter}}"
+                        />
+                    <TextBlock
+                        FontWeight="SemiBold"
+                        FontSize="18"
+                        Opacity=".75"
+                        Visibility="{x:Bind CurrentTeam.IsPrivateChat, Converter={StaticResource BoolToVisibilityConverter}, ConverterParameter='invert'}"
+                        Text="{x:Bind CurrentChannel.ChannelName, Mode=OneWay}"
+                        />
+                </StackPanel>
                 <TextBlock
                     Text="{x:Bind CurrentTeam.Description, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                     FontSize="14"
                     Opacity=".75"
                     TextTrimming="WordEllipsis"
-                    VerticalAlignment="Bottom"
+                    VerticalAlignment="Center"
                     />
             </StackPanel>
             <Button

--- a/Messenger/Messenger/Controls/ChatControls/ChatHeader.xaml.cs
+++ b/Messenger/Messenger/Controls/ChatControls/ChatHeader.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Messenger.ViewModels.DataViewModels;
+using System.Linq;
 using System.Windows.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -42,6 +43,15 @@ namespace Messenger.Controls.ChatControls
 
         public static readonly DependencyProperty CurrentTeamProperty =
             DependencyProperty.Register("CurrentTeam", typeof(TeamViewModel), typeof(ChatHeader), new PropertyMetadata(null));
+
+        public ChannelViewModel CurrentChannel
+        {
+            get { return (ChannelViewModel)GetValue(CurrentChannelProperty); }
+            set { SetValue(CurrentChannelProperty, value); }
+        }
+
+        public static readonly DependencyProperty CurrentChannelProperty =
+            DependencyProperty.Register("CurrentChannel", typeof(ChannelViewModel), typeof(ChatHeader), new PropertyMetadata(null));
 
         public ChatHeader()
         {

--- a/Messenger/Messenger/Controls/Navigation/SideNavigation.xaml
+++ b/Messenger/Messenger/Controls/Navigation/SideNavigation.xaml
@@ -32,8 +32,15 @@
                 </Setter.Value>
             </Setter>
         </Style>
+        <Style x:Key="MenuPanelStyle" TargetType="StackPanel">
+            <Setter Property="Spacing" Value="3" />
+        </Style>
+        <Style x:Key="MenuTextStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="10" />
+        </Style>
     </UserControl.Resources>
     <Grid
+        Padding="0 10 0 0"
         HorizontalAlignment="Stretch">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
@@ -47,10 +54,17 @@
             Style="{StaticResource NavigationButtonStyle}"
             Command="{x:Bind NavigateToTeams}"
             IsChecked="True">
-            <SymbolIcon
-                x:Name="TeamIcon"
-                Symbol="People">
-            </SymbolIcon>
+            <StackPanel Style="{StaticResource MenuPanelStyle}">
+                <SymbolIcon
+                    x:Name="TeamIcon"
+                    Symbol="People">
+                </SymbolIcon>
+                <TextBlock
+                    x:Name="TeamText"
+                    Text="Teams"
+                    Style="{StaticResource MenuTextStyle}"
+                    />
+            </StackPanel>
             <i:Interaction.Behaviors>
                 <ic:DataTriggerBehavior
                     Binding="{Binding IsChecked, ElementName=TeamsButton}"
@@ -60,12 +74,22 @@
                         PropertyName="Foreground"
                         Value="{ThemeResource SystemAccentColor}"
                         />
+                    <ic:ChangePropertyAction
+                        TargetObject="{Binding ElementName=TeamText}"
+                        PropertyName="Foreground"
+                        Value="{ThemeResource SystemAccentColor}"
+                        />
                 </ic:DataTriggerBehavior>
                 <ic:DataTriggerBehavior
                     Binding="{Binding IsChecked, ElementName=TeamsButton}"
                     Value="False">
                     <ic:ChangePropertyAction
                         TargetObject="{Binding ElementName=TeamIcon}"
+                        PropertyName="Foreground"
+                        Value="{ThemeResource SystemAccentColorDark1}"
+                        />
+                    <ic:ChangePropertyAction
+                        TargetObject="{Binding ElementName=TeamText}"
                         PropertyName="Foreground"
                         Value="{ThemeResource SystemAccentColorDark1}"
                         />
@@ -78,17 +102,29 @@
             Grid.Column="1"
             Style="{StaticResource NavigationButtonStyle}"
             Command="{x:Bind NavigateToChats}">
-            <SymbolIcon
-                x:Name="ChatIcon"
-                Symbol="Comment"
-                Foreground="{StaticResource AppBarItemForegroundThemeBrush}">
-            </SymbolIcon>
+            <StackPanel Style="{StaticResource MenuPanelStyle}">
+                <SymbolIcon
+                    x:Name="ChatsIcon"
+                    Symbol="Comment"
+                    Foreground="{StaticResource AppBarItemForegroundThemeBrush}">
+                </SymbolIcon>
+                <TextBlock
+                    x:Name="ChatsText"
+                    Text="Chats"
+                    Style="{StaticResource MenuTextStyle}"
+                    />
+            </StackPanel>
             <i:Interaction.Behaviors>
                 <ic:DataTriggerBehavior
                     Binding="{Binding IsChecked, ElementName=ChatsButton}"
                     Value="True">
                     <ic:ChangePropertyAction
-                        TargetObject="{Binding ElementName=ChatIcon}"
+                        TargetObject="{Binding ElementName=ChatsIcon}"
+                        PropertyName="Foreground"
+                        Value="{ThemeResource SystemAccentColor}"
+                        />
+                    <ic:ChangePropertyAction
+                        TargetObject="{Binding ElementName=ChatsText}"
                         PropertyName="Foreground"
                         Value="{ThemeResource SystemAccentColor}"
                         />
@@ -97,7 +133,12 @@
                     Binding="{Binding IsChecked, ElementName=ChatsButton}"
                     Value="False">
                     <ic:ChangePropertyAction
-                        TargetObject="{Binding ElementName=ChatIcon}"
+                        TargetObject="{Binding ElementName=ChatsIcon}"
+                        PropertyName="Foreground"
+                        Value="{ThemeResource SystemAccentColorDark1}"
+                        />
+                    <ic:ChangePropertyAction
+                        TargetObject="{Binding ElementName=ChatsText}"
                         PropertyName="Foreground"
                         Value="{ThemeResource SystemAccentColorDark1}"
                         />
@@ -110,17 +151,29 @@
             x:Name="NotificationsButton"
             Style="{StaticResource NavigationButtonStyle}"
             Command="{x:Bind NavigateToNotifications}">
-            <SymbolIcon
-                x:Name="NotificationIcon"
-                Symbol="Mail"
-                Foreground="{StaticResource AppBarItemForegroundThemeBrush}">
-            </SymbolIcon>
+            <StackPanel Style="{StaticResource MenuPanelStyle}">
+                <SymbolIcon
+                    x:Name="NotificationsIcon"
+                    Symbol="Mail"
+                    Foreground="{StaticResource AppBarItemForegroundThemeBrush}">
+                </SymbolIcon>
+                <TextBlock
+                    x:Name="NotificationsText"
+                    Text="Notifications"
+                    Style="{StaticResource MenuTextStyle}"
+                    />
+            </StackPanel>
             <i:Interaction.Behaviors>
                 <ic:DataTriggerBehavior
                         Binding="{Binding IsChecked, ElementName=NotificationsButton}"
                         Value="True">
                     <ic:ChangePropertyAction
-                            TargetObject="{Binding ElementName=NotificationIcon}"
+                            TargetObject="{Binding ElementName=NotificationsIcon}"
+                            PropertyName="Foreground"
+                            Value="{ThemeResource SystemAccentColor}"
+                            />
+                    <ic:ChangePropertyAction
+                            TargetObject="{Binding ElementName=NotificationsText}"
                             PropertyName="Foreground"
                             Value="{ThemeResource SystemAccentColor}"
                             />
@@ -129,7 +182,12 @@
                         Binding="{Binding IsChecked, ElementName=NotificationsButton}"
                         Value="False">
                     <ic:ChangePropertyAction
-                            TargetObject="{Binding ElementName=NotificationIcon}"
+                            TargetObject="{Binding ElementName=NotificationsIcon}"
+                            PropertyName="Foreground"
+                            Value="{ThemeResource SystemAccentColorDark1}"
+                            />
+                    <ic:ChangePropertyAction
+                            TargetObject="{Binding ElementName=NotificationsText}"
                             PropertyName="Foreground"
                             Value="{ThemeResource SystemAccentColorDark1}"
                             />

--- a/Messenger/Messenger/Helpers/MessageManager.cs
+++ b/Messenger/Messenger/Helpers/MessageManager.cs
@@ -48,6 +48,21 @@ namespace Messenger.Helpers
             return _messagesByChannelId.TryGetValue(channelId, out messages);
         }
 
+        public bool TryGetLastMessage(uint channelId, out MessageViewModel message)
+        {
+            if (TryGetMessages(channelId, out ObservableCollection<MessageViewModel> messages)
+                && messages.Count > 0)
+            {
+                message = messages.LastOrDefault();
+                return true;
+            }
+            else
+            {
+                message = null;
+                return false;
+            }
+        }
+
         /// <summary>
         /// Adds the message to the dictionary
         /// </summary>

--- a/Messenger/Messenger/Helpers/TeamBuilder.cs
+++ b/Messenger/Messenger/Helpers/TeamBuilder.cs
@@ -13,8 +13,6 @@ namespace Messenger.Helpers
 {
     public class TeamBuilder
     {
-        private readonly UserViewModel _user;
-
         public TeamBuilder()
         {
         }
@@ -51,6 +49,7 @@ namespace Messenger.Helpers
                 TeamName = team.Name,
                 Description = team.Description,
                 CreationDate = team.CreationDate,
+                IsPrivateChat = string.IsNullOrEmpty(team.Name),
                 Members = new ObservableCollection<User>(),
                 Channels = new ObservableCollection<ChannelViewModel>()
             };

--- a/Messenger/Messenger/Models/PrivateChat.cs
+++ b/Messenger/Messenger/Models/PrivateChat.cs
@@ -1,5 +1,6 @@
 ﻿using Messenger.Core.Models;
 using Messenger.ViewModels.DataViewModels;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace Messenger.Models
@@ -10,6 +11,10 @@ namespace Messenger.Models
     public class PrivateChat : TeamViewModel
     {
         public User Partner { get; set; }
+
+        public MessageViewModel LastMessage { get; set; }
+
+        public ChannelViewModel MainChannel { get; set; }
 
         /// <summary>
         /// Creates a PrivateChat object from the given team data
@@ -28,12 +33,16 @@ namespace Messenger.Models
 
             User partner = teamData.Members.FirstOrDefault();
 
+            ChannelViewModel mainChannel = teamData.Channels.FirstOrDefault(); // Private chat has only one channel
+
             return new PrivateChat()
             {
                 Id = teamData.Id,
                 TeamName = string.Empty,
                 Description = teamData.Description,
                 CreationDate = teamData.CreationDate,
+                LastMessage = mainChannel.LastMessage,
+                MainChannel = mainChannel,
                 Partner = partner
             };
         }

--- a/Messenger/Messenger/ViewModels/DataViewModels/ChannelViewModel.cs
+++ b/Messenger/Messenger/ViewModels/DataViewModels/ChannelViewModel.cs
@@ -10,6 +10,7 @@ namespace Messenger.ViewModels.DataViewModels
         private uint _channelId;
         private string _description;
         private uint _teamId;
+        private MessageViewModel _lastMessage;
 
         public MessageViewModel PinnedMessage
         {
@@ -39,6 +40,12 @@ namespace Messenger.ViewModels.DataViewModels
         {
             get { return _teamId; }
             set { Set(ref _teamId, value); }
+        }
+
+        public MessageViewModel LastMessage
+        {
+            get { return _lastMessage; }
+            set { Set(ref _lastMessage, value); }
         }
 
         public ChannelViewModel()

--- a/Messenger/Messenger/ViewModels/DataViewModels/TeamViewModel.cs
+++ b/Messenger/Messenger/ViewModels/DataViewModels/TeamViewModel.cs
@@ -1,11 +1,7 @@
 ﻿using Messenger.Core.Models;
 using Messenger.Helpers;
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Messenger.ViewModels.DataViewModels
 {
@@ -17,6 +13,7 @@ namespace Messenger.ViewModels.DataViewModels
         private DateTime _creationDate;
         private ObservableCollection<User> _members;
         private ObservableCollection<ChannelViewModel> _channels;
+        private bool _isPrivateChat;
 
         public uint? Id
         {
@@ -52,6 +49,12 @@ namespace Messenger.ViewModels.DataViewModels
         {
             get { return _channels; }
             set { Set(ref _channels, value); }
+        }
+
+        public bool IsPrivateChat
+        {
+            get { return _isPrivateChat; }
+            set { Set(ref _isPrivateChat, value); }
         }
 
         public TeamViewModel()

--- a/Messenger/Messenger/ViewModels/MainPanels/ChatViewModel.cs
+++ b/Messenger/Messenger/ViewModels/MainPanels/ChatViewModel.cs
@@ -100,6 +100,14 @@ namespace Messenger.ViewModels
             }
         }
 
+        public ChannelViewModel CurrentChannel
+        {
+            get
+            {
+                return Hub.CurrentChannel;
+            }
+        }
+
         #endregion
 
         #region Commands
@@ -141,7 +149,7 @@ namespace Messenger.ViewModels
 
             // Register events
             Hub.TeamSwitched += OnTeamSwitched;
-            Hub.MessageReceived += OnMessagesUpdated;
+            Hub.MessageReceived += OnMessageReceived;
             Hub.MessageUpdated += OnMessagesUpdated;
             Hub.MessageDeleted += OnMessagesUpdated;
 
@@ -230,6 +238,16 @@ namespace Messenger.ViewModels
 
         /// <summary>
         /// Fires on MessageReceived of ChatHubService
+        /// </summary>
+        /// <param name="sender">Service that invoked the event</param>
+        /// <param name="message">Received Message object</param>
+        private void OnMessageReceived(object sender, MessageViewModel vm)
+        {
+            Messages.Add(vm);
+        }
+
+        /// <summary>
+        /// Fires on MessageUpdated of ChatHubService
         /// </summary>
         /// <param name="sender">Service that invoked the event</param>
         /// <param name="message">Received Message object</param>

--- a/Messenger/Messenger/Views/MainPanels/ChatPage.xaml
+++ b/Messenger/Messenger/Views/MainPanels/ChatPage.xaml
@@ -33,6 +33,7 @@
                     OpenTeamManagerCommand="{x:Bind ViewModel.OpenTeamManagerCommand}"
                     EditTeamDetailsCommand="{x:Bind ViewModel.EditTeamDetailsCommand}"
                     CurrentTeam="{x:Bind ViewModel.CurrentTeam, Mode=OneWay}"
+                    CurrentChannel="{x:Bind ViewModel.CurrentChannel, Mode=OneWay}"
                     />
                 <MenuFlyoutSeparator
                     Grid.Row="1"

--- a/Messenger/Messenger/Views/NavigationPanels/ChatNavPage.xaml
+++ b/Messenger/Messenger/Views/NavigationPanels/ChatNavPage.xaml
@@ -10,32 +10,55 @@
     xmlns:behaviors="using:Messenger.Behaviors"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:shared="using:Messenger.Controls.Shared"
+    xmlns:icons="using:MahApps.Metro.IconPacks"
+    xmlns:converters="using:Messenger.Helpers"
     Style="{StaticResource PageStyle}"
     mc:Ignorable="d">
     <Page.Resources>
+        <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
         <DataTemplate x:Key="ChatTemplate" x:DataType="model:PrivateChat">
             <my:TreeViewItem
-                IsExpanded="False">
+                IsExpanded="False"
+                Padding="0 10">
                 <StackPanel
                     VerticalAlignment="Center"
                     HorizontalAlignment="Stretch"
                     Orientation="Horizontal">
-                    <TextBlock
-                        Text="{Binding
-                            Partner.DisplayName,
-                            Mode=TwoWay,
-                            UpdateSourceTrigger=PropertyChanged,
-                            FallbackValue='',
-                            TargetNullValue=''}"
-                        Margin="{StaticResource XXSmallTopRightBottomMargin}"
-                        />
-                    <TextBlock
-                        VerticalAlignment="Center"
-                        Foreground="DodgerBlue"
-                        Opacity=".5">
-                        <Run Text="#" />
-                        <Run Text="{Binding Id}" />
-                    </TextBlock>
+                    <StackPanel
+                        Spacing="10"
+                        Orientation="Horizontal">
+                        <Viewbox
+                            Width="32"
+                            Height="32">
+                            <Border
+                                Background="{ThemeResource SystemAccentColor}"
+                                CornerRadius="50"
+                                Padding="6">
+                                <icons:PackIconFontAwesome
+                                    Kind="UsersSolid"
+                                    Foreground="{ThemeResource AppBarItemForegroundThemeBrush}"
+                                    />
+                            </Border>
+                        </Viewbox>
+                        <StackPanel>
+                            <TextBlock
+                                Text="{Binding Partner.DisplayName, Mode=OneWay}"/>
+                            <TextBlock
+                                Visibility="{Binding MainChannel.LastMessage, Converter={StaticResource NullToVisibilityConverter}}"
+                                FontSize="12"
+                                Opacity=".75">
+                                <Run
+                                    Text="{Binding MainChannel.LastMessage.Sender.DisplayName}"
+                                    />
+                                <Run
+                                    Text=":"
+                                    />
+                                <Run
+                                    Text="{Binding MainChannel.LastMessage.Content}"
+                                    />
+                                </TextBlock>
+                        </StackPanel>
+                    </StackPanel>
                 </StackPanel>
             </my:TreeViewItem>
         </DataTemplate>
@@ -61,10 +84,8 @@
             </Setter>
         </Style>
         <Style x:Key="NewChatButtonStyle" TargetType="Button">
-            <Setter Property="VerticalAlignment" Value="Bottom" />
             <Setter Property="HorizontalAlignment" Value="Right" />
             <Setter Property="Background" Value="Transparent" />
-            <Setter Property="Margin" Value="30 0 0 30" />
             <Setter Property="CornerRadius" Value="1" />
         </Style>
 
@@ -75,20 +96,62 @@
 
     <Grid x:Name="ContentArea">
         <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
+        <Grid
+            Padding="32 25 20 25"
+            BorderThickness="0 0 0 1"
+            BorderBrush="{ThemeResource SystemAccentColorLight1}"
+            HorizontalAlignment="Stretch">
+            <StackPanel
+                Spacing="10"
+                Orientation="Horizontal">
+                <TextBlock
+                    Text="Chats"
+                    FontSize="20"
+                    />
+                <TextBlock
+                    VerticalAlignment="Center"
+                    Foreground="{ThemeResource SystemAccentColor}"
+                    FontSize="12">
+                    <Run
+                        Text="{x:Bind ViewModel.Chats.Count, Mode=OneWay}"
+                        />
+                    <Run
+                        Text="Chats active"
+                        />
+                </TextBlock>
+            </StackPanel>
+            <!-- CREATE NEW TEAM -->
+            <Button
+                x:Name="newChat"
+                Style="{StaticResource NewChatButtonStyle}"
+                Command="{x:Bind ViewModel.StartChatCommand}">
+                <Viewbox
+                    Height="18"
+                    Width="18">
+                    <StackPanel
+                        Orientation="Horizontal">
+                        <icons:PackIconFontAwesome
+                            Kind="CommentMedicalSolid"
+                            Foreground="{ThemeResource SystemAccentColor}"
+                            />
+                    </StackPanel>
+                </Viewbox>
+            </Button>
+        </Grid>
 
         <!-- LOADING CONTROL -->
         <shared:OnLoading
-            Grid.Row="0"
+            Grid.Row="1"
             LoadingText="Loading Chats.."
             IsBusy="{x:Bind ViewModel.IsBusy, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
             />
 
         <!-- CHATS LIST -->
         <ScrollViewer
-            Grid.Row="0">
+            Grid.Row="1">
             <StackPanel
                 Margin="0 0 0 20">
                 <my:TreeView
@@ -103,31 +166,6 @@
                     />
             </StackPanel>
         </ScrollViewer>
-
-        <!-- CREATE NEW TEAM -->
-        <Button
-            x:Name="newChat"
-            Style="{StaticResource NewChatButtonStyle}"
-            Command="{x:Bind ViewModel.StartChatCommand}"
-            Grid.Row="1">
-            <Viewbox
-                Height="18">
-                <StackPanel
-                    Orientation="Horizontal">
-                    <TextBlock
-                        Text="Start Chat"
-                        Foreground="{ThemeResource SystemAccentColor}"
-                        Margin="0 0 5 0"
-                        FontWeight="SemiBold"
-                        />
-                    <FontIcon
-                        FontFamily="Segoe MDL2 Assets"
-                        Glyph="&#xE90A;"
-                        Foreground="{ThemeResource SystemAccentColor}"
-                        />
-                </StackPanel>
-            </Viewbox>
-        </Button>
     </Grid>
 
     <!--#endregion-->

--- a/Messenger/Messenger/Views/NavigationPanels/TeamNavPage.xaml
+++ b/Messenger/Messenger/Views/NavigationPanels/TeamNavPage.xaml
@@ -11,32 +11,78 @@
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:models="using:Messenger.ViewModels.DataViewModels"
     xmlns:shared="using:Messenger.Controls.Shared"
+    xmlns:icons="using:MahApps.Metro.IconPacks"
     xmlns:templateSelectors="using:Messenger.TemplateSelectors"
+    xmlns:converters="using:Messenger.Helpers"
     mc:Ignorable="d">
     <Page.Resources>
+        <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
         <DataTemplate x:Key="TeamTemplate" x:DataType="models:TeamViewModel">
             <my:TreeViewItem
                 IsExpanded="False"
-                ItemsSource="{Binding}">
+                ItemsSource="{Binding Channels}"
+                Padding="0 10">
                 <StackPanel
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Center"
+                    Spacing="10"
                     Orientation="Horizontal">
-                    <TextBlock Text="{Binding TeamName}" Margin="{StaticResource XXSmallTopRightBottomMargin}" />
+                    <Viewbox
+                        Width="32"
+                        Height="32">
+                        <Border
+                            Background="{ThemeResource SystemAccentColor}"
+                            CornerRadius="50"
+                            Padding="6">
+                            <icons:PackIconFontAwesome
+                                Kind="UsersSolid"
+                                Foreground="{ThemeResource AppBarItemForegroundThemeBrush}"
+                                />
+                        </Border>
+                    </Viewbox>
                     <TextBlock
                         VerticalAlignment="Center"
-                        Foreground="DodgerBlue"
-                        Opacity=".5">
-                        <Run Text="#" />
-                        <Run Text="{Binding Id}" />
-                    </TextBlock>
+                        Text="{Binding TeamName}"
+                        />
                 </StackPanel>
             </my:TreeViewItem>
         </DataTemplate>
+
         <DataTemplate x:Key="TeamChannelTemplate" x:DataType="models:ChannelViewModel">
             <my:TreeViewItem
                 ItemsSource="{Binding}">
-                <TextBlock Text="{x:Bind ChannelName}" Margin="{StaticResource XXSmallTopRightBottomMargin}" />
+                <StackPanel
+                    Spacing="15"
+                    Orientation="Horizontal">
+                    <Viewbox
+                        Width="16"
+                        Height="16">
+                        <icons:PackIconFontAwesome
+                            Kind="BookmarkSolid"
+                            Foreground="{ThemeResource TextControlBorderBrushFocused}"
+                            />
+                    </Viewbox>
+                    <StackPanel
+                        Spacing="-2"
+                        Padding="0 5 0 15">
+                        <TextBlock
+                            FontSize="14"
+                            FontWeight="SemiBold"
+                            Text="{Binding ChannelName}"/>
+                        <TextBlock
+                            Visibility="{Binding LastMessage, Converter={StaticResource NullToVisibilityConverter}}"
+                            FontSize="12"
+                            Opacity=".75">
+                            <Run
+                                Text="{Binding LastMessage.Sender.DisplayName}"
+                                />
+                            <Run
+                                Text=":"
+                                />
+                            <Run
+                                Text="{Binding LastMessage.Content}"
+                                />
+                        </TextBlock>
+                    </StackPanel>
+                </StackPanel>
             </my:TreeViewItem>
         </DataTemplate>
         <templateSelectors:TeamDataTemplateSelector
@@ -55,15 +101,11 @@
                     <i:BehaviorCollection>
                         <behaviors:TreeViewCollapseBehavior
                             x:Name="collapseBehavior" />
-                        <ic:EventTriggerBehavior
-                            EventName="ItemInvoked">
-                            <ic:InvokeCommandAction
-                                Command="{x:Bind ViewModel.ItemInvokedCommand}" />
-                        </ic:EventTriggerBehavior>
                     </i:BehaviorCollection>
                 </Setter.Value>
             </Setter>
         </Style>
+
         <Style x:Key="SearchFieldStyle" TargetType="TextBox">
             <Setter Property="Height" Value="30" />
             <Setter Property="Margin" Value="5" />
@@ -74,11 +116,9 @@
             <Setter Property="Visibility" Value="Collapsed" />
         </Style>
         <Style x:Key="NewTeamButtonStyle" TargetType="Button">
-            <Setter Property="VerticalAlignment" Value="Bottom" />
             <Setter Property="HorizontalAlignment" Value="Right" />
             <Setter Property="Background" Value="Transparent" />
-            <Setter Property="Margin" Value="0 0 15 30" />
-            <Setter Property="CornerRadius" Value="1" />
+            <Setter Property="CornerRadius" Value="3" />
         </Style>
 
         <!--#endregion-->
@@ -89,26 +129,70 @@
     <Grid
         x:Name="ContentArea">
         <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-
+        <Grid
+            Padding="32 25 20 25"
+            BorderThickness="0 0 0 1"
+            BorderBrush="{ThemeResource SystemAccentColorLight1}"
+            HorizontalAlignment="Stretch">
+            <StackPanel
+                Spacing="10"
+                Orientation="Horizontal">
+                <TextBlock
+                    Text="Teams"
+                    FontSize="20"
+                    />
+                <TextBlock
+                    VerticalAlignment="Center"
+                    Foreground="{ThemeResource SystemAccentColor}"
+                    FontSize="12">
+                    <Run
+                        Text="{x:Bind ViewModel.Teams.Count, Mode=OneWay}"
+                        />
+                    <Run
+                        Text="Teams active"
+                        />
+                </TextBlock>
+            </StackPanel>
+            <!-- CREATE NEW TEAM -->
+            <Button
+                x:Name="newChat"
+                Style="{StaticResource NewTeamButtonStyle}"
+                Command="{x:Bind ViewModel.CreateTeamCommand}"
+                Grid.Row="0">
+                <Viewbox
+                    Height="18"
+                    Width="18">
+                    <StackPanel
+                        Orientation="Horizontal">
+                        <SymbolIcon
+                            Symbol="AddFriend"
+                            Foreground="{ThemeResource SystemAccentColor}"
+                            />
+                    </StackPanel>
+                </Viewbox>
+            </Button>
+        </Grid>
+        
         <!-- LOADING CONTROL -->
         <shared:OnLoading
-            Grid.Row="0"
+            Grid.Row="1"
             LoadingText="Loading Teams.."
             IsBusy="{x:Bind ViewModel.IsBusy, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
             />
 
         <!-- TEAMS LIST -->
         <ScrollViewer
-            Grid.Row="0">
+            Grid.Row="1">
             <StackPanel
                 Margin="0 0 0 20">
                 <my:TreeView
                     x:Name="treeView"
                     Style="{StaticResource TeamTreeViewStyle}"
                     Grid.Row="1"
+                    ItemInvoked="treeView_ItemInvoked"
                     ItemsSource="{x:Bind
                         ViewModel.Teams,
                         UpdateSourceTrigger=PropertyChanged,
@@ -117,30 +201,6 @@
                     />
             </StackPanel>
         </ScrollViewer>
-
-        <!-- CREATE NEW TEAM -->
-        <Button
-            x:Name="newChat"
-            Style="{StaticResource NewTeamButtonStyle}"
-            Command="{x:Bind ViewModel.CreateTeamCommand}"
-            Grid.Row="1">
-            <Viewbox
-                Height="18">
-                <StackPanel
-                    Orientation="Horizontal">
-                    <TextBlock
-                        Text="Create Team"
-                        Foreground="{ThemeResource SystemAccentColor}"
-                        Margin="0 0 5 0"
-                        FontWeight="SemiBold"
-                        />
-                    <SymbolIcon
-                        Symbol="AddFriend"
-                        Foreground="{ThemeResource SystemAccentColor}"
-                        />
-                </StackPanel>
-            </Viewbox>
-        </Button>
     </Grid>
 
     <!--#endregion-->

--- a/Messenger/Messenger/Views/NavigationPanels/TeamNavPage.xaml.cs
+++ b/Messenger/Messenger/Views/NavigationPanels/TeamNavPage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 
 using Messenger.ViewModels;
+using Messenger.ViewModels.DataViewModels;
 using Windows.System;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
@@ -21,6 +22,18 @@ namespace Messenger.Views
             if (e.Parameter as string != "")
             {
                 ViewModel.ShellViewModel = e.Parameter as ShellViewModel;
+            }
+        }
+
+        private void treeView_ItemInvoked(Microsoft.UI.Xaml.Controls.TreeView sender, Microsoft.UI.Xaml.Controls.TreeViewItemInvokedEventArgs args)
+        {
+            switch (args.InvokedItem)
+            {
+                case ChannelViewModel channel:
+                    ViewModel.SwitchChannelCommand.Execute(channel);
+                    break;
+                default:
+                    break;
             }
         }
     }

--- a/Messenger/Messenger/Views/ShellPage.xaml
+++ b/Messenger/Messenger/Views/ShellPage.xaml
@@ -9,7 +9,7 @@
     Style="{StaticResource PageStyle}">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="100"/>
+            <RowDefinition Height="75"/>
             <RowDefinition Height="8*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>


### PR DESCRIPTION
# Before this PR can be merged, the following checkboxes have to be ticked

- [x] New functions with more than 5 lines have docstrings
- [x] Changes introduce no commented out code or `Console.Writeline()` statements used for debugging

# Related issues:

closes #212

## Changes

- `Message` is bound to `Channel` instead of `Team`
- `TeamNavPage` properly shows `Channel`s and `LastMessage`s
- `ChatNavPage` is not expandable and clicking on `PrivateChat` navigates directly to `ChatPage`

## Preview

### Teams
![image](https://user-images.githubusercontent.com/68469414/125664722-b6b4e2b9-9172-49d0-8bf4-159c6924666f.png)

### Chats
![image](https://user-images.githubusercontent.com/68469414/125665094-8be5ba64-3fd8-440f-8c45-ff80c1a999b5.png)

