### PR TITLE
Binding `Attachment` to `MessageView`

### DIFF
--- a/Messenger/Messenger/Commands/Messenger/DownloadAttachmentCommand.cs
+++ b/Messenger/Messenger/Commands/Messenger/DownloadAttachmentCommand.cs
@@ -1,0 +1,65 @@
+﻿using Messenger.Core.Helpers;
+using Messenger.Core.Services;
+using Messenger.Helpers.MessageHelpers;
+using Messenger.Models;
+using Messenger.ViewModels.DataViewModels;
+using Messenger.Views.DialogBoxes;
+using Serilog;
+using System;
+using System.Windows.Input;
+using Windows.Storage;
+
+namespace Messenger.Commands.Messenger
+{
+    public class DownloadAttachmentCommand : ICommand
+    {
+        private readonly MessageViewModel _viewModel;
+        private ILogger _logger => GlobalLogger.Instance;
+
+        public event EventHandler CanExecuteChanged;
+
+        public DownloadAttachmentCommand(MessageViewModel viewModel)
+        {
+            _viewModel = viewModel;
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Opens the file open picker and sets the model for AttachmentsBlobName, if any selected
+        /// </summary>
+        public async void Execute(object parameter)
+        {
+            bool executable = parameter != null
+                && parameter is Attachment;
+
+            if (!executable) return;
+
+            try
+            {
+                Attachment target = parameter as Attachment;
+                string destinationDirectory = UserDataPaths.GetDefault().Downloads;
+
+                bool success = await FileSharingService.Download(target.ToBlobName(), destinationDirectory);
+
+                if (success)
+                {
+                    await ResultConfirmationDialog
+                        .Set(true, $"Download successful (Path: {destinationDirectory}")
+                        .ShowAsync();
+                }
+
+            }
+            catch (Exception e)
+            {
+                _logger.Information($"Error while fetching files from the device: {e.Message}");
+                await ResultConfirmationDialog
+                        .Set(false, $"Download failed. Try again.")
+                        .ShowAsync();
+            }
+        }
+    }
+}

--- a/Messenger/Messenger/Helpers/MessageHelpers/MessageBuilder.cs
+++ b/Messenger/Messenger/Helpers/MessageHelpers/MessageBuilder.cs
@@ -260,6 +260,36 @@ namespace Messenger.Helpers.MessageHelpers
             return attachmentsList;
         }
 
+        public static string ToBlobName(this Attachment attachment)
+        {
+            if (attachment == null)
+            {
+                return string.Empty;
+            }
+
+            string blobName = string.Join('.', attachment.FileName, attachment.FileType, attachment.UploaderId);
+
+            return blobName;
+        }
+
+        public static IEnumerable<string> ToBlobNames(this List<Attachment> attachments)
+        {
+            if (attachments == null || attachments.Count() <= 0)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            List<string> blobNamesList = new List<string>();
+
+            foreach (Attachment attachment in attachments)
+            {
+                string blobName = string.Join('.', attachment.FileName, attachment.FileType, attachment.UploaderId);
+                blobNamesList.Add(blobName);
+            }
+
+            return blobNamesList;
+        }
+
         #endregion
     }
 }

--- a/Messenger/Messenger/Helpers/MessageHelpers/MessageBuilder.cs
+++ b/Messenger/Messenger/Helpers/MessageHelpers/MessageBuilder.cs
@@ -30,16 +30,10 @@ namespace Messenger.Helpers.MessageHelpers
         public static async Task<MessageViewModel> Build(this Message message)
         {
             MessageViewModel withReactions = await Map(message).WithReactions();
-            withReactions = await withReactions.WithReplies();
+            MessageViewModel withReplies = await withReactions.WithReplies();
+            MessageViewModel withAttachments = await withReplies.WithAttachments();
 
-            if (withReactions.Sender == null)
-            {
-                return await withReactions.WithSender();
-            }
-            else
-            {
-                return withReactions;
-            }
+            return withAttachments.Sender == null ? await withAttachments.WithSender() : withAttachments;
         }
 
         /// <summary>
@@ -140,6 +134,18 @@ namespace Messenger.Helpers.MessageHelpers
             return viewModel;
         }
 
+        public static async Task<MessageViewModel> WithAttachments(this MessageViewModel viewModel)
+        {
+            IEnumerable<string> blobNames = await MessageService.GetBlobFileNamesOfAttachments((uint)viewModel.Id);
+
+            if (blobNames != null && blobNames.Count() > 0)
+            {
+                viewModel.Attachments = blobNames.Parse();
+            }
+
+            return viewModel;
+        }
+
         /// <summary>
         /// Sorts parent-messages/replies and assigns replies to matching parents
         /// this should be called only after converting all loaded messages to view models
@@ -186,6 +192,7 @@ namespace Messenger.Helpers.MessageHelpers
         public static MessageViewModel Map(Message message)
         {
             bool isReply = (message.ParentMessageId != null) ? true : false;
+            bool hasAttachments = (message.AttachmentsBlobName != null && message.AttachmentsBlobName.Count() > 0);
 
             return new MessageViewModel()
             {
@@ -195,7 +202,7 @@ namespace Messenger.Helpers.MessageHelpers
                 Content = message.Content,
                 CreationTime = message.CreationTime,
                 ChannelId = message.RecipientId,
-                Attachments = message.AttachmentsBlobName.Parse(),
+                Attachments = hasAttachments ? message.AttachmentsBlobName.Parse() : new List<Attachment>(),
                 IsReply = isReply,
                 IsMyMessage = App.StateProvider.CurrentUser.Id == message.SenderId,
                 HasReacted = false

--- a/Messenger/Messenger/Messenger.csproj
+++ b/Messenger/Messenger/Messenger.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Behaviors\NavigationViewHeaderBehavior.cs" />
     <Compile Include="Behaviors\NavigationViewHeaderMode.cs" />
     <Compile Include="Behaviors\TreeViewCollapseBehavior.cs" />
+    <Compile Include="Commands\Messenger\DownloadAttachmentCommand.cs" />
     <Compile Include="Commands\Messenger\DeleteMessageCommand.cs" />
     <Compile Include="Commands\Messenger\UpdateMessageCommand.cs" />
     <Compile Include="Commands\PrivateChat\StartChatWithUserCommand.cs" />

--- a/Messenger/Messenger/ViewModels/DataViewModels/MessageViewModel.cs
+++ b/Messenger/Messenger/ViewModels/DataViewModels/MessageViewModel.cs
@@ -1,10 +1,12 @@
 ﻿using MahApps.Metro.IconPacks;
+using Messenger.Commands.Messenger;
 using Messenger.Core.Models;
 using Messenger.Models;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Windows.Input;
 
 namespace Messenger.ViewModels.DataViewModels
 {
@@ -187,6 +189,8 @@ namespace Messenger.ViewModels.DataViewModels
                 Set(ref _myReaction, value);
             }
         }
+
+        public ICommand DownloadAttachmentCommand { get => new DownloadAttachmentCommand(this); }
 
         public MessageViewModel()
         {

--- a/Messenger/Messenger/Views/Subcontrols/MessageView.xaml
+++ b/Messenger/Messenger/Views/Subcontrols/MessageView.xaml
@@ -393,11 +393,32 @@
                                 ElementName=AttachmentsExpandButton,
                                 Path=IsChecked,
                                 Converter={StaticResource BoolToVisConverter}}">
-                            <!-- PLACEHOLDER -->
-                            <Button
-                                Style="{StaticResource AttachmentHypertext}"
-                                Content="example_data_02941.png (114.22 KB)"
-                                />
+                            <ItemsControl
+                                ItemsSource="{x:Bind
+                                    Message.Attachments,
+                                    Mode=OneWay}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="models:Attachment">
+                                        <StackPanel
+                                            Orientation="Horizontal">
+                                            <Button
+                                                Style="{StaticResource AttachmentHypertext}"
+                                                Content="{Binding FileName}"
+                                                Command="{Binding
+                                                    ElementName=messageView,
+                                                    Path=Message.DownloadAttachmentCommand}"
+                                                CommandParameter="{Binding}"
+                                                />
+                                            <TextBlock
+                                                Text="."
+                                                />
+                                            <TextBlock
+                                                Text="{Binding FileType}"
+                                                />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
                         </StackPanel>
                     </StackPanel>
                     <!-- MESSAGE ACTIONS (REPLY/UPDATE/DELETE) -->


### PR DESCRIPTION
# Before this PR can be merged, the following checkboxes have to be ticked

- [x] New functions with more than 5 lines have docstrings
- [x] Changes introduce no commented out code or `Console.Writeline()` statements used for debugging

# Related issues:
closes #149 with #201 
